### PR TITLE
breaking: added compiler modules option

### DIFF
--- a/lib/cucumber/cucumber_configuration.js
+++ b/lib/cucumber/cucumber_configuration.js
@@ -62,7 +62,7 @@ extend(CucumberConfiguration.prototype, {
     var supportFiles         = process.env.SUPPORT_FILES.split(','),
         extensions           = ['js', 'coffee'],
         supportCodeFilePaths = Cucumber.Cli.SupportCodePathExpander.expandPaths(supportFiles, extensions),
-        compilerModules      = ['coffee-script/register'],
+        compilerModules      = process.env.WORKER_MODULES.split(','),
         supportCodeLoader    = Cucumber.Cli.SupportCodeLoader(supportCodeFilePaths, compilerModules);
     return supportCodeLoader.getSupportCodeLibrary();
   },

--- a/lib/cucumber/cucumber_configuration.js
+++ b/lib/cucumber/cucumber_configuration.js
@@ -62,7 +62,7 @@ extend(CucumberConfiguration.prototype, {
     var supportFiles         = process.env.SUPPORT_FILES.split(','),
         extensions           = ['js', 'coffee'],
         supportCodeFilePaths = Cucumber.Cli.SupportCodePathExpander.expandPaths(supportFiles, extensions),
-        compilerModules      = process.env.WORKER_MODULES.split(','),
+        compilerModules      = process.env.COMPILER_MODULES.split(','),
         supportCodeLoader    = Cucumber.Cli.SupportCodeLoader(supportCodeFilePaths, compilerModules);
     return supportCodeLoader.getSupportCodeLibrary();
   },

--- a/lib/fork_worker.js
+++ b/lib/fork_worker.js
@@ -14,13 +14,16 @@
  * limitations under the License.
  **/
 
-require('coffee-script');
-require('coffee-script/register');
-require('babel-register');
-require('babel-polyfill');
+var cluster       = require('cluster'),
+    path          = require('path'),
+    workerModules = process.env.WORKER_MODULES.split(',');
 
-var cluster = require('cluster'),
-    path    = require('path');
+for (var workerModuleIndex in workerModules) {
+  var workerModule = workerModules[workerModuleIndex];
+  if (workerModule.length > 0) {
+    require(workerModule);
+  }
+}
 
 if (!process.env.WORKER_SCRIPT) {
   throw new Error('No worker script specified');

--- a/lib/fork_worker.js
+++ b/lib/fork_worker.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  **/
 
-var cluster       = require('cluster'),
-    path          = require('path'),
-    workerModules = process.env.WORKER_MODULES.split(',');
+var cluster         = require('cluster'),
+    path            = require('path'),
+    compilerModules = process.env.COMPILER_MODULES.split(',');
 
-for (var workerModuleIndex in workerModules) {
-  var workerModule = workerModules[workerModuleIndex];
-  if (workerModule.length > 0) {
-    require(workerModule);
+for (var compilerModuleIndex in compilerModules) {
+  var compilerModule = compilerModules[compilerModuleIndex];
+  if (compilerModule.length > 0) {
+    require(compilerModule);
   }
 }
 

--- a/lib/functional.js
+++ b/lib/functional.js
@@ -71,7 +71,8 @@ module.exports = Functional = {
 
     this.options = extend({
       requestedPorts : 0,
-      type           : this.TYPE_MOCHA
+      type           : this.TYPE_MOCHA,
+      workerModules  : []
     }, options);
 
     this.eventMediator = new EventEmitter();
@@ -274,7 +275,8 @@ module.exports = Functional = {
       timeout        : this.options.timeout,
       type           : this.options.type,
       reportsUrl     : this.options.reportsUrl,
-      supportFiles   : this.options.supportFiles || []
+      supportFiles   : this.options.supportFiles || [],
+      workerModules  : this.options.workerModules
     });
   },
 

--- a/lib/functional.js
+++ b/lib/functional.js
@@ -70,9 +70,9 @@ module.exports = Functional = {
     }
 
     this.options = extend({
-      requestedPorts : 0,
-      type           : this.TYPE_MOCHA,
-      workerModules  : []
+      requestedPorts  : 0,
+      type            : this.TYPE_MOCHA,
+      compilerModules : []
     }, options);
 
     this.eventMediator = new EventEmitter();
@@ -266,17 +266,17 @@ module.exports = Functional = {
    **/
   _getServerInstance : function (port, requestedPorts) {
     return new ServerInstance({
-      port           : port,
-      requestedPorts : requestedPorts,
-      server         : this.options.server,
-      maxMemory      : this.options.maxMemory,
-      maxTests       : this.options.maxTests,
-      slow           : this.options.slow,
-      timeout        : this.options.timeout,
-      type           : this.options.type,
-      reportsUrl     : this.options.reportsUrl,
-      supportFiles   : this.options.supportFiles || [],
-      workerModules  : this.options.workerModules
+      port            : port,
+      requestedPorts  : requestedPorts,
+      server          : this.options.server,
+      maxMemory       : this.options.maxMemory,
+      maxTests        : this.options.maxTests,
+      slow            : this.options.slow,
+      timeout         : this.options.timeout,
+      type            : this.options.type,
+      reportsUrl      : this.options.reportsUrl,
+      supportFiles    : this.options.supportFiles || [],
+      compilerModules : this.options.compilerModules
     });
   },
 

--- a/lib/server_instance.js
+++ b/lib/server_instance.js
@@ -19,17 +19,17 @@ var cluster      = require('cluster'),
     extend       = require('extend');
 
 function ServerInstance (options) {
-  this.exit           = false
-  this.port           = options.port;
-  this.requestedPorts = options.requestedPorts;
-  this.maxMemory      = options.maxMemory;
-  this.maxTests       = options.maxTests;
-  this.slow           = options.slow;
-  this.timeout        = options.timeout;
-  this.testType       = options.type;
-  this.reportsUrl     = options.reportsUrl;
-  this.supportFiles   = options.supportFiles || [];
-  this.workerModules  = options.workerModules;
+  this.exit            = false
+  this.port            = options.port;
+  this.requestedPorts  = options.requestedPorts;
+  this.maxMemory       = options.maxMemory;
+  this.maxTests        = options.maxTests;
+  this.slow            = options.slow;
+  this.timeout         = options.timeout;
+  this.testType        = options.type;
+  this.reportsUrl      = options.reportsUrl;
+  this.supportFiles    = options.supportFiles || [];
+  this.compilerModules = options.compilerModules;
 
   this.server        = cluster.fork({
     WORKER_SCRIPT         : options.server || './server',
@@ -42,7 +42,7 @@ function ServerInstance (options) {
     TEST_TYPE             : options.type,
     SUPPORT_FILES         : options.supportFiles,
     REPORTS_URL           : options.reportsUrl,
-    WORKER_MODULES        : options.workerModules
+    COMPILER_MODULES      : options.compilerModules
   });
 
   this._setupListeners();
@@ -106,7 +106,7 @@ extend(ServerInstance.prototype, EventEmitter.prototype, {
       TEST_TYPE             : this.testType,
       SUPPORT_FILES         : this.supportFiles,
       REPORTS_URL           : this.reportsUrl,
-      WORKER_MODULES        : this.workerModules
+      COMPILER_MODULES      : this.compilerModules
     });
 
     runner.on('message', function (message) {

--- a/lib/server_instance.js
+++ b/lib/server_instance.js
@@ -29,6 +29,7 @@ function ServerInstance (options) {
   this.testType       = options.type;
   this.reportsUrl     = options.reportsUrl;
   this.supportFiles   = options.supportFiles || [];
+  this.workerModules  = options.workerModules;
 
   this.server        = cluster.fork({
     WORKER_SCRIPT         : options.server || './server',
@@ -40,7 +41,8 @@ function ServerInstance (options) {
     WORKER_TIMEOUT        : options.timeout,
     TEST_TYPE             : options.type,
     SUPPORT_FILES         : options.supportFiles,
-    REPORTS_URL           : options.reportsUrl
+    REPORTS_URL           : options.reportsUrl,
+    WORKER_MODULES        : options.workerModules
   });
 
   this._setupListeners();
@@ -103,7 +105,8 @@ extend(ServerInstance.prototype, EventEmitter.prototype, {
       WORKER_TIMEOUT        : this.timeout,
       TEST_TYPE             : this.testType,
       SUPPORT_FILES         : this.supportFiles,
-      REPORTS_URL           : this.reportsUrl
+      REPORTS_URL           : this.reportsUrl,
+      WORKER_MODULES        : this.workerModules
     });
 
     runner.on('message', function (message) {

--- a/package.json
+++ b/package.json
@@ -44,11 +44,8 @@
   },
   "homepage": "https://github.com/skytap/minorjs-test",
   "dependencies": {
-    "babel-polyfill": "~6.20.0",
-    "babel-register": "~6.26.0",
     "bluebird": "~2.10.2",
     "cli-table": "~0.3.1",
-    "coffee-script": "~1.10.0",
     "cucumber": "0.9.3",
     "cucumber-junit": "~1.7.0",
     "extend": "~3.0.0",


### PR DESCRIPTION
Provides more flexibility when using babel, coffee, typescript, etc. For example, applications could upgrade to babel 7+ without waiting for a new version of minorjs-test.

Example:

```
Functional.start({
  timeout: 40000,
  requestedPorts: 2,
  type: 'mocha',
  compilerModules: [
    '@babel/register',
    '@babel/polyfill',
    'coffee-script',
    'coffee-script/register'
  ]
})
```