### PR TITLE
Allow passing the delay option to nockjs mock

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -240,6 +240,10 @@ module.exports = Mock = {
       result = result.query(true)
     }
 
+    if (options.delay) {
+      result = result.delay(options.delay)
+    }
+
     return this._getFixture(result, options);
   }
 };


### PR DESCRIPTION
Nockjs allows for mocked requests to have delayed responses.  This change will pass along delay options to the nockjs delay api.