### PR TITLE
gracefully handle EPIPE error

### DIFF
--- a/lib/functional.js
+++ b/lib/functional.js
@@ -303,6 +303,9 @@ module.exports = Functional = {
     });
 
     process.on('uncaughtException', function handleException (error) {
+      if (error.code === 'EPIPE') {
+        return;
+      }
       console.log(error.stack);
       self._bail();
       self._shutdown(1);


### PR DESCRIPTION
According to the doc: https://nodejs.org/docs/latest-v10.x/api/errors.html
> EPIPE (Broken pipe): A write on a pipe, socket, or FIFO for which there is no process to read the data. Commonly encountered at the net and http layers, indicative that the remote side of the stream being written to has been closed.

It is no need to shut down functional tests running for this error. There is also a npm package to ignore EPIPE error
https://github.com/mhart/epipebomb