### PR TITLE
Update nock to v13.0.11 and node dep to 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MinorJS Test Changelog
 
+## Version 10.0.0, April 5th, 2021
+
+* breaking: bump nodejs dependency to >= v10
+* chore: upgrade nock to v13.0.11
+
 ## Version 8.0.2, March 26th, 2019
 
 * bump nodejs dependency to >= v6.4.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "copyright": "Copyright 2016 Skytap Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at     http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.",
   "name": "minorjs-test",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Functional testing framework for the MinorJS web framework.",
   "author": {
     "name": "Skytap",
@@ -32,7 +32,7 @@
   },
   "main": "./index.js",
   "engines": {
-    "node": ">=6.4.0"
+    "node": ">=10"
   },
   "license": "Apache-2.0",
   "readmeFilename": "README.md",
@@ -49,7 +49,7 @@
     "fs-extra": "^2.1.2",
     "glob": "~7.0.5",
     "mocha": "~5.2.0",
-    "nock": "~9.6.1",
+    "nock": "~13.0.11",
     "portfinder": "~1.0.3",
     "underscore": "~1.8.3",
     "zombie": "~6.1.3"


### PR DESCRIPTION
### Update nock to v13.0.11 and node dep to 12

* breaking: bump nodejs dependency to >= v10
* chore: upgrade nock to v13.0.11